### PR TITLE
Don't show annotations url if they are absent

### DIFF
--- a/assets/alertmanager/alertmanager.yaml
+++ b/assets/alertmanager/alertmanager.yaml
@@ -37,7 +37,7 @@ receivers:
       {{ range .Alerts }}
         *Alert:* {{ .Annotations.summary }} - `{{ .Labels.severity }}`
         *Description:* {{ .Annotations.description }}
-          *Graph:* <{{ .GeneratorURL }}|:chart_with_upwards_trend:> *Runbook:* <{{ .Annotations.runbook }}|:spiral_note_pad:>
+        *Graph:* <{{ .GeneratorURL }}|:chart_with_upwards_trend:>{{ if .Annotations.runbook }} *Runbook:* <{{ .Annotations.runbook }}|:spiral_note_pad:>{{ end }}
         *Details:*
         {{ range .Labels.SortedPairs }} • *{{ .Name }}:* `{{ .Value }}`
         {{ end }}


### PR DESCRIPTION
Hi!

Thanks for your work! Here is a small fix which hides annotations link if they are absent. Because of the absence of the value otherwise URL is broken and shown as `*Runbook:* <|:spiral_note_pad:>`.